### PR TITLE
HOTFIX: Fix processing if one item in collection.

### DIFF
--- a/classes/TingMarcxchangeResult.php
+++ b/classes/TingMarcxchangeResult.php
@@ -37,9 +37,14 @@ class TingMarcxchangeResult {
 
     // If `$data` is empty, when assume that collection contains more types of
     // records, so we will extract the main.
-    if (!isset($data)) {
+    if (empty($data)) {
       $data_array = $collectionData->getValue('collection/record');
-      $data = $data_array[0]->getValue('datafield');
+      if ($data_array instanceof JsonOutput) {
+        $data = $data_array->getValue('datafield');
+      }
+      else {
+        $data = $data_array[0]->getValue('datafield');
+      }
     }
 
     return $data;


### PR DESCRIPTION
If there is only one item in collection, it is returned directly as an JsonOutput object without "traditional" wrapping into an array.